### PR TITLE
Bump fluent-bit-out-hsdp app to 2.0.12

### DIFF
--- a/charts/fluent-bit-out-hsdp/Chart.yaml
+++ b/charts/fluent-bit-out-hsdp/Chart.yaml
@@ -6,9 +6,9 @@ keywords:
   - fluent-bit
   - fluentd
   - hsdp
-version: 0.0.14
-appVersion: 1.9.9
-icon: https://fluentbit.io/assets/img/logo1-default.png
+version: 0.0.15
+appVersion: 2.0.12
+icon: https://fluentbit.io/images/logo.svg
 home: https://github.com/philips-software/fluent-bit-out-hsdp
 sources:
   - https://github.com/philips-software/fluent-bit-out-hsdp/

--- a/charts/fluent-bit-out-hsdp/README.md
+++ b/charts/fluent-bit-out-hsdp/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square) ![AppVersion: 1.9.9](https://img.shields.io/badge/AppVersion-1.9.9-informational?style=flat-square)
+![Version: 0.0.15](https://img.shields.io/badge/Version-0.0.15-informational?style=flat-square) ![AppVersion: 2.0.12](https://img.shields.io/badge/AppVersion-2.0.12-informational?style=flat-square)
 
 Installs the Fluentbit HSP out plugin.
 


### PR DESCRIPTION
- Bump plugin to 2.0.12 which fixes a memory leak when using HSP logdrainer credentials
- Fix broken logo of Helm chart