### PR TITLE
tweaking max_label_names_per_series, max_global_series_per_user, inge…

### DIFF
--- a/charts/mimir-bootstrap/Chart.yaml
+++ b/charts/mimir-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mimir-bootstrap
-version: 0.54.0
+version: 0.55.0
 description: A Helm chart for bootstrapping Mimir

--- a/charts/mimir-bootstrap/config/mimir-values.yaml.tmpl
+++ b/charts/mimir-bootstrap/config/mimir-values.yaml.tmpl
@@ -309,9 +309,11 @@ mimir:
         enabled: true
     limits:
       max_label_names_per_series: {{ .Values.limits.maxLabelNamesPerSeries }}
-      max_global_series_per_user: 4000000
+      max_global_series_per_user: 5000000
       out_of_order_time_window: {{ .Values.limits.outOfOrderTimeWindow }}
       max_global_exemplars_per_user: {{ .Values.limits.maxGlobalExemplarsPerUser }}
+      ingestion_rate: 100000
+      ingestion_burst_size: 1000000   
     blocks_storage:
       storage_prefix: blocks
       backend: s3

--- a/charts/mimir-bootstrap/values.yaml
+++ b/charts/mimir-bootstrap/values.yaml
@@ -61,7 +61,7 @@ limits:
   # Accept out-of-order samples up to this duration in the past
   outOfOrderTimeWindow: 30m
   # Maximum number of label names per series
-  maxLabelNamesPerSeries: 35
+  maxLabelNamesPerSeries: 60
   # Maximum number of exemplars stored per user (0 = disabled)
   maxGlobalExemplarsPerUser: 0
 


### PR DESCRIPTION
In testrun of 5000VU's , observed a drop of VU's to 4710 or 4818 hence updating ingestion rate, burst size , max_label_names_per_series and max_global_series_per_user on mimir configuration.