### PR TITLE
Feat/loki distributor resources

### DIFF
--- a/charts/loki-bootstrap/Chart.yaml
+++ b/charts/loki-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: loki-bootstrap
-version: 0.43.0
+version: 0.43.1
 description: A Helm chart for bootstrapping Loki

--- a/charts/loki-bootstrap/config/loki-values.yaml
+++ b/charts/loki-bootstrap/config/loki-values.yaml
@@ -189,10 +189,10 @@ distributor:
   maxUnavailable: 1
   resources:
     requests:
-      cpu: 250m
-      memory: 1Gi
+      cpu: {{ .Values.distributor.resources.requests.cpu }}
+      memory: {{ .Values.distributor.resources.requests.memory }}
     limits:
-      memory: 2Gi
+      memory: {{ .Values.distributor.resources.limits.memory }}
   extraArgs:
     - -config.expand-env=true
   extraEnv:

--- a/charts/loki-bootstrap/values.yaml
+++ b/charts/loki-bootstrap/values.yaml
@@ -70,6 +70,16 @@ gateway:
     limits:
       memory: 128Mi
 
+# Distributor configuration
+distributor:
+  replicas: 3
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      memory: 2Gi
+
 features:
   # Enable the CloudWatch kill job that removes CloudWatch ClusterOutputs
   # and ensures a null-output ClusterOutput exists


### PR DESCRIPTION
- Add templates for distributor resources requests and limits
- Chart version update
- Add distributor replicas default (3)
- Add distributor CPU requests default (250m)
- Add distributor memory requests default (1Gi)
- Add distributor memory limits default (2Gi)
- Values can be overridden per deployment in overrides"