### PR TITLE
templating grpc config for pattern ingester

### DIFF
--- a/charts/loki-bootstrap/Chart.yaml
+++ b/charts/loki-bootstrap/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: loki-bootstrap
-version: 0.43.1
+version: 0.43.2
 description: A Helm chart for bootstrapping Loki

--- a/charts/loki-bootstrap/config/loki-values.yaml
+++ b/charts/loki-bootstrap/config/loki-values.yaml
@@ -280,12 +280,14 @@ patternIngester:
   replicas: {{ .Values.patternIngester.replicas }}
   resources:
     requests:
-      cpu: 50m
-      memory: 512Mi
+      cpu: {{ .Values.patternIngester.resources.requests.cpu }}
+      memory: {{ .Values.patternIngester.resources.requests.memory }}
     limits:
-      memory: 1Gi
+      memory: {{ .Values.patternIngester.resources.limits.memory }}
   extraArgs:
     - -config.expand-env=true
+    - -server.grpc-max-recv-msg-size-bytes={{ .Values.patternIngester.extraArgs.grpc_max_recv_msg_size }}
+    - -server.grpc-max-send-msg-size-bytes={{ .Values.patternIngester.extraArgs.grpc_max_send_msg_size }}
   extraEnv:
     - name: bucketName
       valueFrom:
@@ -367,7 +369,11 @@ loki:
   tracing:
     enabled: true
   pattern_ingester:
-    enabled: true
+    enabled: {{ .Values.loki.pattern_ingester.enabled }}
+    client_config:
+      grpc_client_config:
+        max_recv_msg_size: {{ .Values.loki.pattern_ingester.client_config.grpc_client_config.max_recv_msg_size }}
+        max_send_msg_size: {{ .Values.loki.pattern_ingester.client_config.grpc_client_config.max_send_msg_size }}
   storage:
     type: "s3"
     bucketNames:
@@ -384,8 +390,8 @@ loki:
   auth_enabled: {{ .Values.multitenancyEnabled }}
 
   server:
-    grpc_server_max_recv_msg_size: 83886080
-    grpc_server_max_send_msg_size: 83886080
+    grpc_server_max_recv_msg_size: {{ .Values.loki.server.grpc_server_max_recv_msg_size }}
+    grpc_server_max_send_msg_size: {{ .Values.loki.server.grpc_server_max_send_msg_size }}
   schemaConfig:
     configs:
       - from: "2024-07-05"

--- a/charts/loki-bootstrap/values.yaml
+++ b/charts/loki-bootstrap/values.yaml
@@ -49,6 +49,23 @@ loki:
     # Maximum number of log entries returned by a query (Loki default: 5000)
     max_entries_limit_per_query: 5000
 
+  # gRPC server configuration
+  server:
+    # Maximum size of gRPC messages received (bytes, default: 83886080 = 80MB)
+    grpc_server_max_recv_msg_size: 83886080  # 80MB
+    # Maximum size of gRPC messages sent (bytes, default: 83886080 = 80MB)
+    grpc_server_max_send_msg_size: 83886080  # 80MB
+
+  # Pattern ingester configuration for gRPC
+  pattern_ingester:
+    enabled: true
+    client_config:
+      grpc_client_config:
+        # Maximum size of gRPC messages received by pattern ingester client
+        max_recv_msg_size: 83886080  # 80MB
+        # Maximum size of gRPC messages sent by pattern ingester client
+        max_send_msg_size: 83886080  # 80MB
+
 # Ingester configuration
 ingester:
   # Number of ingester replicas
@@ -59,6 +76,17 @@ ingester:
 patternIngester:
   # Number of pattern ingester replicas
   replicas: 3
+  resources:
+    requests:
+      cpu: 50m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+  extraArgs:
+    # Maximum size of gRPC messages received by pattern ingester (bytes, default: 134217728 = 128MB)
+    grpc_max_recv_msg_size: 83886080  # 80MB
+    # Maximum size of gRPC messages sent by pattern ingester (bytes, default: 134217728 = 128MB)
+    grpc_max_send_msg_size: 83886080  # 80MB
 
 # Gateway configuration
 gateway:


### PR DESCRIPTION
- Template pattern ingester resource limits (CPU, memory)
- Templatize gRPC server message size arguments
- Add loki.server and loki.pattern_ingester configuration templates
- Provide configurable defaults in values.yaml (128MB gRPC messages)
- Allows per-deployment customization of gRPC and resource settings