### PR TITLE
fix(renovate): lift prHourlyLimit so major bumps reach a PR

### DIFF
--- a/.github/renovate-dry-run.sh
+++ b/.github/renovate-dry-run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Test Renovate locally against this repo without opening PRs.
+#
+# Detects which dependency updates Renovate WOULD create, using the live
+# .github/renovate.json5 config and the working tree as-is. Nothing is pushed.
+#
+# Usage:
+#   .github/renovate-dry-run.sh                # full dry-run, all deps
+#   .github/renovate-dry-run.sh caddy-token    # filter output to one dep
+#
+# Requires: the `renovate` CLI (npm i -g renovate, or `brew install renovate`)
+# and a GitHub token (sourced from `gh auth token`) for github-* datasources.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+export RENOVATE_TOKEN="${RENOVATE_TOKEN:-$(gh auth token)}"
+filter="${1:-}"
+
+# --platform=local reads the current checkout; --dry-run=full does lookups but
+# never creates branches/PRs. LOG_LEVEL=debug exposes per-dep newVersion info.
+if [[ -n "$filter" ]]; then
+  LOG_LEVEL=debug renovate --platform=local --dry-run=full 2>&1 \
+    | grep -A12 "\"depName\": .*${filter}" \
+    | grep -iE "depName|newVersion|newValue|updateType|currentValue" || {
+      echo "No update detected for '${filter}' (or dep not found)."
+      exit 1
+    }
+else
+  renovate --platform=local --dry-run=full 2>&1 | grep -iE "flattened updates|Dependency extraction complete" -A4
+fi

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,12 @@
     'config:best-practices',
     ':disableDependencyDashboard',
   ],
+  // config:best-practices defaults prHourlyLimit to 2, which throttles this
+  // repo to 2 PRs per run. With dozens of managed deps and major updates
+  // ordered last, breaking bumps (e.g. caddy-token v1.x) never reached the
+  // front of the queue. Lift the hourly cap; prConcurrentLimit (default 10)
+  // still bounds the number of simultaneously open PRs.
+  prHourlyLimit: 0,
   enabledManagers: ['custom.regex'],
   packageRules: [
     {


### PR DESCRIPTION
## Problem

Renovate detection works fine, but `caddy-token v0.82.0 → v1.0.1` (a **major** bump) never got a PR.

Root cause: `config:best-practices` defaults `prHourlyLimit: 2`. A local dry-run (`renovate --platform=local --dry-run=full`) shows **7 distinct PRs pending**:

| Branch (= 1 PR) | Type |
|---|---|
| `renovate/pin-dependencies` | pinDigest (26 ops grouped into one PR) |
| `renovate/fluent-bit-0.x` | minor |
| `renovate/grafana-alloy-1.x` | minor |
| `renovate/tempo-distributed-2.x` | minor |
| `renovate/grafana-grafana-image-renderer-5.x` | patch |
| `renovate/ghcr.io-crossplane-contrib-function-patch-and-transform-0.x` | patch |
| `renovate/ghcr.io-loafoe-caddy-token-1.x` | **major** |

With only 2 PRs created per run and Renovate ordering major updates last, the caddy-token major bump sits at the back of a 7-deep queue and keeps losing the top-2 race every daily run. Confirmed in the GitHub Action log (`27404288400`): exactly 2 PRs created, neither was caddy-token. Detection (`newVersion: v1.0.1`, `updateType: major`) was never the problem.

## Fix

- Set `prHourlyLimit: 0`. `prConcurrentLimit` (default 10) still bounds simultaneously open PRs, so the daily run drains the full 7-PR backlog instead of dripping 2/run.
- Add `.github/renovate-dry-run.sh` to test detection locally without opening PRs:
  ```
  .github/renovate-dry-run.sh caddy-token
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)