### PR TITLE
docs(renovate): correct pending-PR count in comment

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,9 +13,9 @@
     ':disableDependencyDashboard',
   ],
   // config:best-practices defaults prHourlyLimit to 2, which throttles this
-  // repo to 2 PRs per run. With dozens of managed deps and major updates
-  // ordered last, breaking bumps (e.g. caddy-token v1.x) never reached the
-  // front of the queue. Lift the hourly cap; prConcurrentLimit (default 10)
+  // repo to 2 PRs per run. With ~7 distinct PRs typically pending and major
+  // updates ordered last, breaking bumps (e.g. caddy-token v1.x) never reached
+  // the front of the queue. Lift the hourly cap; prConcurrentLimit (default 10)
   // still bounds the number of simultaneously open PRs.
   prHourlyLimit: 0,
   enabledManagers: ['custom.regex'],


### PR DESCRIPTION
Follow-up to #234. You correctly pointed out there aren't ~32 pending updates.

A local dry-run (`renovate --platform=local --dry-run=full`) shows **7 distinct PRs** pending, not 32 — the "32 flattened updates" log line counts every flattened op, including **26 digest-pins that group into a single `renovate/pin-dependencies` PR** plus cross-file dupes.

This only corrects the misleading comment wording in `renovate.json5`. The fix itself is unchanged and correct: 7 pending > `prHourlyLimit` default of 2, and Renovate orders the major caddy-token bump last, so it was still starved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)