### PR TITLE
fix(otlp-gateway): bump caddy-token to v1.1.1 (fixes exec under hardened securityContext)

### DIFF
--- a/charts/otlp-gateway/Chart.yaml
+++ b/charts/otlp-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: otlp-gateway
-version: 0.58.0
+version: 0.58.1
 description: A Helm chart for Kubernetes to deploy an OTLP gateway with authentication and authorization
 type: application

--- a/charts/otlp-gateway/values.yaml
+++ b/charts/otlp-gateway/values.yaml
@@ -124,7 +124,7 @@ autoscaling:
 caddy:
   container:
     # renovate: datasource=docker depName=ghcr.io/loafoe/caddy-token
-    image: ghcr.io/loafoe/caddy-token:v1.1.0
+    image: ghcr.io/loafoe/caddy-token:v1.1.1
   payloadsize:
     # important: the payloadsize requires an image which includes the payloadsize plugin
     enabled: false


### PR DESCRIPTION
## Problem

On ri-obs-dev the otlp-gateway pod crashed with:

```
exec /usr/bin/caddy: operation not permitted
```

## Root cause

caddy-token **v1.1.0** changed the image to run as a non-root `caddy` user and shipped `/usr/bin/caddy` with an **effective-bit file capability** (`setcap cap_net_bind_service=+ep`).

The chart's securityContext is correctly hardened:
- `allowPrivilegeEscalation: false` → sets `NoNewPrivs` on the container
- `capabilities.drop: [ALL]`

Under `NoNewPrivs`, the Linux kernel **refuses to `execve()` a binary that carries an _effective_ file capability** unless the process already holds that capability in its permitted set — and we drop all of them. Result: EPERM on exec. v1.0.1 ran as root with no file caps, so it never hit this.

Reproduced exactly with `docker run --cap-drop ALL --security-opt no-new-privileges --user 12113 ...`:

| Image | Result |
|---|---|
| v1.1.0 | `exec /usr/bin/caddy: operation not permitted` ❌ |
| v1.0.1 | runs ✓ |
| **v1.1.1** | runs ✓ (amd64 + arm64) |

## Fix

[caddy-token v1.1.1](https://github.com/loafoe/caddy-token/releases/tag/v1.1.1) removes the `setcap` from the image — verified to have **no file capabilities** on the binary. The gateway listens only on high ports (8080/8443/2020), so no net-bind capability is needed. The hardened securityContext (`allowPrivilegeEscalation: false`, `drop: [ALL]`) stays unchanged.

This PR bumps the image to `v1.1.1` and the chart to `0.58.1`.

Verified: `helm template` renders `image: ghcr.io/loafoe/caddy-token:v1.1.1` with the hardened securityContext intact.