### PR TITLE
feat(otlp-gateway): suppress health-check access logs by default

### DIFF
--- a/charts/otlp-gateway/Chart.yaml
+++ b/charts/otlp-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: otlp-gateway
-version: 0.59.0
+version: 0.60.0
 description: A Helm chart for Kubernetes to deploy an OTLP gateway with authentication and authorization
 type: application

--- a/charts/otlp-gateway/README.md
+++ b/charts/otlp-gateway/README.md
@@ -1,6 +1,6 @@
 # otlp-gateway
 
-![Version: 0.59.0](https://img.shields.io/badge/Version-0.59.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.60.0](https://img.shields.io/badge/Version-0.60.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 OTLP gateway is a reference implementation which creates a single otlphttp endpoint that proxies Loki, Tempo and Mimir OTLP endpoints
 It supports authentication and authorization using both static and JWT tokens and tokens through the [caddy-token](https://github.com/loafoe/caddy-token) plugin.
@@ -102,7 +102,7 @@ authn:
 | ingress.enabled | bool | `true` |  |
 | loadbalancer.enabled | bool | `false` |  |
 | log.level | string | `"error"` |  |
-| log.suppressHealthChecks | bool | `false` |  |
+| log.suppressHealthChecks | bool | `true` |  |
 | loki.enabled | bool | `true` |  |
 | loki.pathPrefix | string | `"/v1/logs"` |  |
 | loki.service | string | `"loki-gateway.loki-system.svc.cluster.local:80"` |  |

--- a/charts/otlp-gateway/values.yaml
+++ b/charts/otlp-gateway/values.yaml
@@ -75,7 +75,7 @@ pyroscope:
 log:
   level: error
   # Suppress health check logs (/api/health endpoint)
-  suppressHealthChecks: false
+  suppressHealthChecks: true
 
 # CORS configuration for browser-based OTLP clients
 cors:


### PR DESCRIPTION
## What

Flip the `log.suppressHealthChecks` default from `false` to `true` in the otlp-gateway chart.

## Why

The `:8080` Caddy server logs every request via its access log, including the `kube-probe` GETs to `/api/health`. With liveness/readiness probes hitting it continuously, these dominate the access log and add no operational value. The chart already supports suppressing them via the `log_skip` directive (`config/Caddyfile`); this just makes suppression the default.

`log.level` already defaults to `error`, so combined with this change the gateway is quiet out of the box. Operators who want probe logs back can set `log.suppressHealthChecks: false`.

## Changes
- `values.yaml`: `log.suppressHealthChecks: false` → `true`
- `Chart.yaml`: `0.59.0` → `0.60.0`
- `README.md`: regenerated via helm-docs

## Verification
`helm template` with no overrides now renders `log_skip` inside `handle /api/health` and `level error` on the server block. The existing `log.level` validator still rejects invalid values.