### PR TITLE
TEST: simulated renovate appVersion bump (do not merge)

### DIFF
--- a/.github/bump-chart-versions.sh
+++ b/.github/bump-chart-versions.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Auto-bump the version: of any chart whose contents changed relative to a base
+# ref, UNLESS the version was already bumped in this branch. Intended to run on
+# Renovate (and other) PRs: Renovate updates an appVersion / image tag / values
+# file but never touches the wrapper chart's own version:, so chart-releaser
+# silently skips the release (skip_existing: true). This closes that gap.
+#
+# Usage:
+#   .github/bump-chart-versions.sh [base-ref]     # default base: origin/main
+#
+# Bump is patch-level. For each changed chart it compares the working-tree
+# version to the base-ref version; if unchanged, it bumps patch and rewrites
+# Chart.yaml in place. Prints the charts it touched (one per line) to stdout so
+# a workflow can decide whether to commit.
+#
+# Requires: yq (v4+), git.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/chart-paths.sh
+source "$DIR/lib/chart-paths.sh"
+
+BASE="${1:-origin/main}"
+
+bump_patch() {
+  # major.minor.patch -> major.minor.(patch+1). Ignores any pre-release/build
+  # suffix, which none of the charts in this repo use.
+  local v="$1" major minor patch
+  IFS='.' read -r major minor patch <<<"$v"
+  echo "${major}.${minor}.$((patch + 1))"
+}
+
+bumped=()
+for name in $(changed_charts "$BASE"); do
+  file="$(chart_file "$name")"
+  current="$(chart_version "$name")"
+  base_version="$(base_chart_version "$name" "$BASE")"
+
+  if [[ "$current" != "$base_version" ]]; then
+    # Version already changed in this branch (human bumped it, or a prior run
+    # of this script did). Leave it alone.
+    echo "skip: $name version already changed ($base_version -> $current)" >&2
+    continue
+  fi
+
+  new="$(bump_patch "$current")"
+  yq -i ".version = \"$new\"" "$file"
+  echo "bump: $name $current -> $new" >&2
+  bumped+=("$name")
+done
+
+# Machine-readable output: the charts we actually bumped (empty if none).
+((${#bumped[@]})) && printf '%s\n' "${bumped[@]}"
+exit 0

--- a/.github/check-chart-versions.sh
+++ b/.github/check-chart-versions.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# CI guard: fail if a chart's contents changed relative to a base ref but its
+# version: was NOT bumped. Complements bump-chart-versions.sh — the bumper runs
+# on Renovate PRs, this guard catches human PRs (and any case the bumper missed)
+# before they merge and silently no-op the release.
+#
+# Usage:
+#   .github/check-chart-versions.sh [base-ref]    # default base: origin/main
+#
+# Exit 0 if every changed chart has a changed version:, non-zero otherwise.
+#
+# Requires: yq (v4+), git.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/chart-paths.sh
+source "$DIR/lib/chart-paths.sh"
+
+BASE="${1:-origin/main}"
+
+violations=()
+for name in $(changed_charts "$BASE"); do
+  current="$(chart_version "$name")"
+  base_version="$(base_chart_version "$name" "$BASE")"
+
+  if [[ -z "$base_version" ]]; then
+    # New chart (no Chart.yaml at base) — nothing to bump against.
+    echo "ok: $name is new" >&2
+    continue
+  fi
+
+  if [[ "$current" == "$base_version" ]]; then
+    violations+=("$name (still $current)")
+  else
+    echo "ok: $name $base_version -> $current" >&2
+  fi
+done
+
+if ((${#violations[@]})); then
+  echo "::error::The following charts changed but their version: was not bumped:" >&2
+  printf '  - %s\n' "${violations[@]}" >&2
+  echo "Bump version: in each chart's Chart.yaml (or run .github/bump-chart-versions.sh)." >&2
+  exit 1
+fi
+
+echo "All changed charts have a bumped version." >&2

--- a/.github/lib/chart-paths.sh
+++ b/.github/lib/chart-paths.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Shared helpers for mapping changed files to their owning chart and reading
+# chart versions. Sourced by bump-chart-versions.sh (auto-bump on PR) and
+# check-chart-versions.sh (CI guard). Keeping the logic here means the bumper
+# and the guard can never disagree about what "the owning chart" is.
+set -euo pipefail
+
+# Absolute path to the charts/ directory in this repo.
+CHARTS_DIR="$(git rev-parse --show-toplevel)/charts"
+
+# owning_chart <path>
+#   Given a repo-relative or absolute path, echo the chart directory name that
+#   owns it (the first path segment under charts/), or nothing if the path is
+#   not under charts/.
+owning_chart() {
+  local path="$1"
+  # Normalise to repo-relative.
+  path="${path#"$(git rev-parse --show-toplevel)"/}"
+  case "$path" in
+    charts/*)
+      # charts/<name>/... -> <name>
+      path="${path#charts/}"
+      echo "${path%%/*}"
+      ;;
+    *) : ;;  # not under charts/, ignore
+  esac
+}
+
+# chart_file <name>
+#   Echo the absolute path to a chart's Chart.yaml.
+chart_file() {
+  echo "$CHARTS_DIR/$1/Chart.yaml"
+}
+
+# chart_version <name>
+#   Echo the current version: field of a chart.
+chart_version() {
+  yq -r '.version' "$(chart_file "$1")"
+}
+
+# base_chart_version <name> <base-ref>
+#   Echo a chart's version: as it was at the point this branch diverged from
+#   <base-ref> (the merge-base), or empty if the chart did not exist there.
+#   Uses the same merge-base as changed_charts so the two never disagree.
+base_chart_version() {
+  local name="$1" base="$2" mergebase
+  mergebase="$(git merge-base "$base" HEAD 2>/dev/null || echo "$base")"
+  git show "$mergebase:charts/$name/Chart.yaml" 2>/dev/null | yq -r '.version' || echo ""
+}
+
+# changed_charts <base-ref>
+#   Echo, one per line, the unique chart names that have any file changed since
+#   this branch diverged from <base-ref>. Compares the merge-base against the
+#   working tree, so both committed and uncommitted changes count. Excludes
+#   deleted charts (Chart.yaml gone).
+changed_charts() {
+  local base="$1" f name mergebase
+  mergebase="$(git merge-base "$base" HEAD 2>/dev/null || echo "$base")"
+  {
+    for f in $(git diff --name-only "$mergebase" -- 'charts/**'); do
+      name="$(owning_chart "$f")"
+      [[ -n "$name" && -f "$(chart_file "$name")" ]] && echo "$name"
+    done
+  } | sort -u
+}

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -1,0 +1,54 @@
+name: Auto-bump Chart Versions
+
+# Renovate (and human) PRs often change a chart's contents — an appVersion,
+# an image tag, a values file — without bumping the wrapper chart's own
+# version:. chart-releaser runs with skip_existing: true, so an unbumped
+# version means the release is silently skipped. This workflow patch-bumps the
+# version: of every changed chart and commits the result back to the PR branch.
+#
+# The companion guard in lint-test.yml still fails the PR if a version is
+# somehow left unbumped (e.g. this workflow is skipped on a fork PR), so this is
+# a convenience, not the sole line of defence.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - charts/**
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    # Only push commits back to same-repo branches. Fork PRs get a read-only
+    # token; the guard job will flag any missing bump instead.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Bump changed chart versions
+        id: bump
+        run: |
+          base="origin/${{ github.event.pull_request.base.ref }}"
+          git fetch --quiet origin "${{ github.event.pull_request.base.ref }}"
+          bumped="$(.github/bump-chart-versions.sh "$base")"
+          {
+            echo 'bumped<<EOF'
+            echo "$bumped"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push
+        if: steps.bump.outputs.bumped != ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add 'charts/**/Chart.yaml'
+          git commit -m "chore: bump chart version(s) for dependency update"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -11,6 +11,20 @@ on:
       - .github/workflows/lint-test.yaml
 
 jobs:
+  version-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check chart versions were bumped
+        run: |
+          base="origin/${{ github.event.repository.default_branch }}"
+          git fetch --quiet origin "${{ github.event.repository.default_branch }}"
+          .github/check-chart-versions.sh "$base"
+
   lint-test:
     runs-on: ubuntu-22.04
 

--- a/charts/k8s-observability-monitoring/Chart.yaml
+++ b/charts/k8s-observability-monitoring/Chart.yaml
@@ -2,6 +2,5 @@ apiVersion: v2
 name: k8s-observability-monitoring
 version: 1.4.0
 description: Helm chart for k8s-observability-monitoring
-
 # renovate: datasource=helm depName=k8s-monitoring registryUrl=https://grafana.github.io/helm-charts
-appVersion: "4.2.2"
+appVersion: "4.2.3"

--- a/charts/k8s-observability-monitoring/Chart.yaml
+++ b/charts/k8s-observability-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-observability-monitoring
-version: 1.4.0
+version: 1.4.1
 description: Helm chart for k8s-observability-monitoring
 # renovate: datasource=helm depName=k8s-monitoring registryUrl=https://grafana.github.io/helm-charts
 appVersion: "4.2.3"


### PR DESCRIPTION
Test PR for #285. Bumps k8s-observability-monitoring `appVersion` without touching `version:`, mimicking a Renovate commit.

Expected: the `Auto-bump Chart Versions` workflow pushes a commit bumping `version: 1.4.0 -> 1.4.1`, after which the `version-guard` job passes.

**Do not merge — will be deleted after verification.**