### PR TITLE
ci: regenerate helm-docs when chart dependencies change

### DIFF
--- a/.github/regen-chart-docs.sh
+++ b/.github/regen-chart-docs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Regenerate helm-docs README.md for every chart changed since a base ref.
+# Runs alongside bump-chart-versions.sh: a dependency PR changes appVersion /
+# image tags / values, which drift the Version/AppVersion badges and value
+# tables in the generated README. Scoped per-chart so unrelated stale docs
+# elsewhere in the repo are NOT swept into the PR.
+#
+# Usage:
+#   .github/regen-chart-docs.sh [base-ref]        # default base: origin/main
+#
+# Requires: helm-docs, git.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/chart-paths.sh
+source "$DIR/lib/chart-paths.sh"
+
+BASE="${1:-origin/main}"
+
+for name in $(changed_charts "$BASE"); do
+  # Only charts that actually use helm-docs (have a template or existing README).
+  if [[ -f "$CHARTS_DIR/$name/README.md.gotmpl" || -f "$CHARTS_DIR/$name/README.md" ]]; then
+    echo "helm-docs: $name" >&2
+    helm-docs --chart-search-root="charts/$name" >&2
+  fi
+done

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -3,8 +3,12 @@ name: Auto-bump Chart Versions
 # Renovate (and human) PRs often change a chart's contents — an appVersion,
 # an image tag, a values file — without bumping the wrapper chart's own
 # version:. chart-releaser runs with skip_existing: true, so an unbumped
-# version means the release is silently skipped. This workflow patch-bumps the
-# version: of every changed chart and commits the result back to the PR branch.
+# version means the release is silently skipped. This workflow, for every
+# changed chart:
+#   1. patch-bumps version: (unless already bumped in the branch), and
+#   2. regenerates the helm-docs README (Version/AppVersion badges + value
+#      tables drift on any dependency change),
+# then commits both back to the PR branch.
 #
 # The companion guard in lint-test.yml still fails the PR if a version is
 # somehow left unbumped (e.g. this workflow is skipped on a fork PR), so this is
@@ -40,23 +44,35 @@ jobs:
           # won't auto-rerun).
           token: ${{ secrets.CHART_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Bump changed chart versions
-        id: bump
+      - name: Install helm-docs
+        env:
+          # renovate: datasource=github-releases depName=norwoodj/helm-docs
+          HELM_DOCS_VERSION: 1.14.2
+        run: |
+          curl -fsSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin helm-docs
+          helm-docs --version
+
+      - name: Bump versions and regenerate docs
         run: |
           base="origin/${{ github.event.pull_request.base.ref }}"
           git fetch --quiet origin "${{ github.event.pull_request.base.ref }}"
-          bumped="$(.github/bump-chart-versions.sh "$base")"
-          {
-            echo 'bumped<<EOF'
-            echo "$bumped"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
+          .github/bump-chart-versions.sh "$base"
+          # Docs run AFTER the bump so the regenerated Version badge reflects the
+          # new version. Scoped to changed charts only.
+          .github/regen-chart-docs.sh "$base"
 
       - name: Commit and push
-        if: steps.bump.outputs.bumped != ''
         run: |
+          # Commit whatever changed — a version bump, a regenerated README, or
+          # both. Nothing to do if the tree is clean (e.g. version was already
+          # bumped by hand and docs were already current).
+          if git diff --quiet -- charts/; then
+            echo "No chart changes to commit."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add 'charts/**/Chart.yaml'
-          git commit -m "chore: bump chart version(s) for dependency update"
+          git add 'charts/**/Chart.yaml' 'charts/**/README.md'
+          git commit -m "chore: bump chart version(s) and regenerate docs for dependency update"
           git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Problem

Follow-up to #285. Dependency PRs bump `appVersion` / image tags / values, which drift the **helm-docs generated README** — the `![Version]`/`![AppVersion]` badges and value tables. Nothing regenerated them, so READMEs were already stale (e.g. `k8s-observability-monitoring` README showed `AppVersion: 4.1.7` while `Chart.yaml` was `4.2.2`). Our own auto-bump would have drifted the `Version` badge too.

## Solution

- `.github/regen-chart-docs.sh` — runs `helm-docs` per changed chart, **scoped** with `--chart-search-root` so unrelated stale docs elsewhere aren't swept into the PR. Reuses `lib/chart-paths.sh`.
- `chart-version-bump.yml`:
  - installs `helm-docs` from the official release (pinned + Renovate-tracked via `HELM_DOCS_VERSION`),
  - runs the version bump **then** doc regen (so the regenerated Version badge reflects the new version),
  - commits on **any** resulting diff (bump, README, or both).

## Verified locally

Simulated an `appVersion 4.2.2→4.2.3` change → regen updated only that chart's README (badge `4.1.7→4.2.3`), no other chart touched. Renovate regex confirmed to track `norwoodj/helm-docs` releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)