### PR TITLE
fix(agentgateway-bootstrap): add GatewayClass, default ClusterIP dataplane, fix namespace

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 
@@ -33,6 +33,7 @@ A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kuber
 | gateway.enabled | bool | `true` |  |
 | gateway.name | string | `"agentgateway"` |  |
 | gateway.namespace | string | `"agentgateway-system"` |  |
+| gateway.service.type | string | `"ClusterIP"` |  |
 | monitoring.enabled | bool | `true` |  |
 | monitoring.grafanaDashboard.enabled | bool | `true` |  |
 | monitoring.serviceMonitor.enabled | bool | `true` |  |

--- a/charts/agentgateway-bootstrap/templates/agentgateway-crds-helm.yaml
+++ b/charts/agentgateway-bootstrap/templates/agentgateway-crds-helm.yaml
@@ -18,7 +18,7 @@ spec:
     targetRevision: {{ .Values.agentgatewayCrdsChart.version | quote }}
   destination:
     server: "https://kubernetes.default.svc"
-    namespace: agentgateway-system
+    namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
   syncPolicy:
     syncOptions:
       - CreateNamespace=true

--- a/charts/agentgateway-bootstrap/templates/agentgateway-helm.yaml
+++ b/charts/agentgateway-bootstrap/templates/agentgateway-helm.yaml
@@ -27,7 +27,7 @@ spec:
         {{- (tpl (.Files.Get "config/agentgateway-values.yaml") .) | nindent 8 }}
   destination:
     server: "https://kubernetes.default.svc"
-    namespace: agentgateway-system
+    namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
   syncPolicy:
     syncOptions:
       - CreateNamespace=true

--- a/charts/agentgateway-bootstrap/templates/gateway-parameters.yaml
+++ b/charts/agentgateway-bootstrap/templates/gateway-parameters.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayParameters
+metadata:
+  name: {{ .Values.gateway.name }}-params
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  service:
+    spec:
+      type: {{ .Values.gateway.service.type | default "ClusterIP" }}
+{{- end }}

--- a/charts/agentgateway-bootstrap/templates/gatewayclass.yaml
+++ b/charts/agentgateway-bootstrap/templates/gatewayclass.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: {{ .Values.gateway.className }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  controllerName: agentgateway.dev/agentgateway
+  parametersRef:
+    group: agentgateway.dev
+    kind: AgentgatewayParameters
+    name: {{ .Values.gateway.name }}-params
+    namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+{{- end }}

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -47,6 +47,11 @@ gateway:
   name: agentgateway
   className: agentgateway
   namespace: agentgateway-system
+  # Service type for the dynamically-provisioned per-Gateway dataplane Service.
+  # The embedded agentgateway-standalone chart defaults this to LoadBalancer;
+  # override to ClusterIP unless external exposure is explicitly wanted.
+  service:
+    type: ClusterIP
 
 # Admin UI internal service configuration
 ui:


### PR DESCRIPTION
## Summary
- Adds a `GatewayClass` (`controllerName: agentgateway.dev/agentgateway`) — the chart created a `Gateway` but never the class it binds to.
- Adds an `AgentgatewayParameters` resource so the dynamically-provisioned per-Gateway dataplane Service defaults to `ClusterIP` instead of upstream's `LoadBalancer` default.
- Fixes `agentgateway-crds-helm.yaml`/`agentgateway-helm.yaml` to deploy into `gateway.namespace` instead of the hardcoded `agentgateway-system`, matching every other template in the chart.
- Bumps chart version to `0.4.0`.

## Test plan
- [x] `helm template` renders GatewayClass/AgentgatewayParameters with expected controllerName/type
- [x] `helm lint` passes