### PR TITLE
fix(agentgateway-bootstrap): skip dry-run for agentgateway.dev objects

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 

--- a/charts/agentgateway-bootstrap/templates/bedrock-backend.yaml
+++ b/charts/agentgateway-bootstrap/templates/bedrock-backend.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   ai:
     provider:

--- a/charts/agentgateway-bootstrap/templates/gateway-parameters.yaml
+++ b/charts/agentgateway-bootstrap/templates/gateway-parameters.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   service:
     spec:

--- a/charts/agentgateway-bootstrap/templates/gateway.yaml
+++ b/charts/agentgateway-bootstrap/templates/gateway.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   gatewayClassName: {{ .Values.gateway.className }}
   listeners:

--- a/charts/agentgateway-bootstrap/templates/gatewayclass.yaml
+++ b/charts/agentgateway-bootstrap/templates/gatewayclass.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   controllerName: agentgateway.dev/agentgateway
   parametersRef:

--- a/charts/agentgateway-bootstrap/templates/tracing-policy.yaml
+++ b/charts/agentgateway-bootstrap/templates/tracing-policy.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io


### PR DESCRIPTION
## Summary
Fixes a chart bug found during live-cluster deployment: the agentgateway-bootstrap
Application failed every ArgoCD sync because AgentgatewayParameters/GatewayClass/
Gateway/AgentgatewayPolicy/AgentgatewayBackend (all agentgateway.dev/v1alpha1 or
depending on it) were dry-run validated before the child agentgateway-crds
Application (same sync op, wave 0) could install their CRDs.

Adds `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` to all 5
affected templates — the same fix already used in this repo for identical CRD+CR
ordering problems (dex-issuer, cloudnative-pg-operator, grafana, crossplane-providers).

## Test plan
- [x] helm template confirms all 5 objects now carry the annotation
- [x] helm lint passes