### PR TITLE
fix(agentgateway-bootstrap): switch upstream registry to ghcr.io/agentgateway/charts

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 
@@ -8,9 +8,9 @@ A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kuber
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agentgatewayChart.repoURL | string | `"oci://cr.agentgateway.dev/charts"` |  |
+| agentgatewayChart.repoURL | string | `"oci://ghcr.io/agentgateway/charts"` |  |
 | agentgatewayChart.version | string | `"1.3.1"` |  |
-| agentgatewayCrdsChart.repoURL | string | `"oci://cr.agentgateway.dev/charts"` |  |
+| agentgatewayCrdsChart.repoURL | string | `"oci://ghcr.io/agentgateway/charts"` |  |
 | agentgatewayCrdsChart.version | string | `"1.3.1"` |  |
 | argoProject | string | `"default"` |  |
 | bedrock.auth.secretName | string | `"bedrock-secret"` |  |

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -2,14 +2,14 @@
 
 # Upstream agentgateway-crds Helm chart configuration
 agentgatewayCrdsChart:
-  repoURL: oci://cr.agentgateway.dev/charts
-  # renovate: datasource=docker depName=cr.agentgateway.dev/charts/agentgateway-crds
+  repoURL: oci://ghcr.io/agentgateway/charts
+  # renovate: datasource=docker depName=ghcr.io/agentgateway/charts/agentgateway-crds
   version: 1.3.1
 
 # Upstream agentgateway Helm chart configuration
 agentgatewayChart:
-  repoURL: oci://cr.agentgateway.dev/charts
-  # renovate: datasource=docker depName=cr.agentgateway.dev/charts/agentgateway
+  repoURL: oci://ghcr.io/agentgateway/charts
+  # renovate: datasource=docker depName=ghcr.io/agentgateway/charts/agentgateway
   version: 1.3.1
 
 # ArgoCD project name


### PR DESCRIPTION
## Summary
ArgoCD's repo-server failed to resolve `cr.agentgateway.dev/charts:1.3.1` during a live
sync (`cannot get digest for revision 1.3.1: ... not found`), despite a direct `helm
pull` from the same pod succeeding. Switches both upstream chart repoURLs
(`agentgatewayCrdsChart`, `agentgatewayChart`) to `ghcr.io/agentgateway/charts`, which
was confirmed to serve byte-identical content (same digests) for both charts at 1.3.1.

## Test plan
- [x] helm template shows both child Applications now use ghcr.io/agentgateway/charts
- [x] zero remaining references to cr.agentgateway.dev
- [x] helm lint passes
- [x] both charts confirmed independently pullable from the new registry