### PR TITLE
fix(agentgateway-bootstrap): fold chart name into repoURL for OCI sources

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 
@@ -8,9 +8,9 @@ A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kuber
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| agentgatewayChart.repoURL | string | `"oci://ghcr.io/agentgateway/charts"` |  |
+| agentgatewayChart.repoURL | string | `"oci://cr.agentgateway.dev/charts"` |  |
 | agentgatewayChart.version | string | `"1.3.1"` |  |
-| agentgatewayCrdsChart.repoURL | string | `"oci://ghcr.io/agentgateway/charts"` |  |
+| agentgatewayCrdsChart.repoURL | string | `"oci://cr.agentgateway.dev/charts"` |  |
 | agentgatewayCrdsChart.version | string | `"1.3.1"` |  |
 | argoProject | string | `"default"` |  |
 | bedrock.auth.secretName | string | `"bedrock-secret"` |  |

--- a/charts/agentgateway-bootstrap/templates/agentgateway-crds-helm.yaml
+++ b/charts/agentgateway-bootstrap/templates/agentgateway-crds-helm.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   project: {{ .Values.argoProject }}
   source:
-    chart: agentgateway-crds
-    repoURL: {{ .Values.agentgatewayCrdsChart.repoURL | quote }}
+    repoURL: {{ printf "%s/agentgateway-crds" .Values.agentgatewayCrdsChart.repoURL | quote }}
     targetRevision: {{ .Values.agentgatewayCrdsChart.version | quote }}
   destination:
     server: "https://kubernetes.default.svc"

--- a/charts/agentgateway-bootstrap/templates/agentgateway-helm.yaml
+++ b/charts/agentgateway-bootstrap/templates/agentgateway-helm.yaml
@@ -18,8 +18,7 @@ spec:
       jsonPointers:
         - /spec/replicas
   source:
-    chart: agentgateway
-    repoURL: {{ .Values.agentgatewayChart.repoURL | quote }}
+    repoURL: {{ printf "%s/agentgateway" .Values.agentgatewayChart.repoURL | quote }}
     targetRevision: {{ .Values.agentgatewayChart.version | quote }}
     helm:
       releaseName: agentgateway

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -2,14 +2,14 @@
 
 # Upstream agentgateway-crds Helm chart configuration
 agentgatewayCrdsChart:
-  repoURL: oci://ghcr.io/agentgateway/charts
-  # renovate: datasource=docker depName=ghcr.io/agentgateway/charts/agentgateway-crds
+  repoURL: oci://cr.agentgateway.dev/charts
+  # renovate: datasource=docker depName=cr.agentgateway.dev/charts/agentgateway-crds
   version: 1.3.1
 
 # Upstream agentgateway Helm chart configuration
 agentgatewayChart:
-  repoURL: oci://ghcr.io/agentgateway/charts
-  # renovate: datasource=docker depName=ghcr.io/agentgateway/charts/agentgateway
+  repoURL: oci://cr.agentgateway.dev/charts
+  # renovate: datasource=docker depName=cr.agentgateway.dev/charts/agentgateway
   version: 1.3.1
 
 # ArgoCD project name


### PR DESCRIPTION
## Summary
Root cause of repeated live-cluster sync failures ("cannot get digest for revision
1.3.1: cr.agentgateway.dev/charts:1.3.1: not found"): ArgoCD's `ApplicationSource.IsOCI()`
matches purely on the `oci://` prefix of `repoURL`, and is checked before `IsHelm()`.
Our two child-Application templates set both `repoURL: oci://.../charts` and a separate
`chart: agentgateway-crds`/`chart: agentgateway` field, which routed resolution through
the wrong code path (raw OCI-repo browsing, which ignores `Chart` entirely).

Fixes both templates to fold the chart name into `repoURL` (no separate `chart:` field),
matching every other working OCI `HelmApplication` in the consuming repo. Also reverts
the `0.4.2` registry switch to `ghcr.io/agentgateway/charts` — that was chasing this same
symptom under an incorrect diagnosis; `ghcr.io/agentgateway/charts` actually requires
authentication for anonymous pulls (confirmed 403 on anonymous token exchange), while
`cr.agentgateway.dev` correctly grants anonymous access (confirmed 200).

## Test plan
- [x] helm template shows both child Applications with full chart path in repoURL, no chart: field
- [x] helm lint passes
- [x] both charts independently confirmed pullable from cr.agentgateway.dev at the full path