### PR TITLE
fix(agentgateway-bootstrap): add missing path: . to folded-repoURL sources

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 

--- a/charts/agentgateway-bootstrap/templates/agentgateway-crds-helm.yaml
+++ b/charts/agentgateway-bootstrap/templates/agentgateway-crds-helm.yaml
@@ -15,6 +15,7 @@ spec:
   source:
     repoURL: {{ printf "%s/agentgateway-crds" .Values.agentgatewayCrdsChart.repoURL | quote }}
     targetRevision: {{ .Values.agentgatewayCrdsChart.version | quote }}
+    path: .
   destination:
     server: "https://kubernetes.default.svc"
     namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}

--- a/charts/agentgateway-bootstrap/templates/agentgateway-helm.yaml
+++ b/charts/agentgateway-bootstrap/templates/agentgateway-helm.yaml
@@ -20,6 +20,7 @@ spec:
   source:
     repoURL: {{ printf "%s/agentgateway" .Values.agentgatewayChart.repoURL | quote }}
     targetRevision: {{ .Values.agentgatewayChart.version | quote }}
+    path: .
     helm:
       releaseName: agentgateway
       valuesObject:


### PR DESCRIPTION
## Summary
Follow-up to #301 (folding chart name into repoURL to work around ArgoCD's
IsOCI()/IsHelm() branching bug). That change left spec.source with only repoURL and
targetRevision, which ArgoCD's Application CRD rejects:
`spec.source.repoURL and either spec.source.path or spec.source.chart are required`

Adds `path: .` to both agentgateway-crds and agentgateway-helm Application templates,
matching the pattern already used by every other folded-repoURL OCI HelmApplication in
the consuming repo.

## Test plan
- [x] helm template shows path: . present in both fixed source blocks
- [x] helm lint passes