### PR TITLE
fix(agentgateway-bootstrap): rename default gateway.name to avoid Deployment collision

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 
@@ -31,7 +31,7 @@ A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kuber
 | environmentConfig.resourcePrefix | string | `""` |  |
 | gateway.className | string | `"agentgateway"` |  |
 | gateway.enabled | bool | `true` |  |
-| gateway.name | string | `"agentgateway"` |  |
+| gateway.name | string | `"agentgateway-gw"` |  |
 | gateway.namespace | string | `"agentgateway-system"` |  |
 | gateway.service.type | string | `"ClusterIP"` |  |
 | monitoring.enabled | bool | `true` |  |

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -44,7 +44,12 @@ bedrock:
 # Kubernetes Gateway resource configuration
 gateway:
   enabled: true
-  name: agentgateway
+  # Must differ from the Helm release name used for the upstream agentgateway
+  # controller install (see agentgateway-helm.yaml's releaseName: agentgateway) -
+  # the controller dynamically provisions a per-Gateway dataplane Deployment
+  # named after this Gateway object, which collides with the controller's own
+  # Helm-managed Deployment if the names match.
+  name: agentgateway-gw
   className: agentgateway
   namespace: agentgateway-system
   # Service type for the dynamically-provisioned per-Gateway dataplane Service.


### PR DESCRIPTION
## Summary
Live-cluster testing surfaced the agentgateway controller stuck in a retry loop trying
to overwrite its own Helm-managed Deployment:
```
Deployment.apps "agentgateway" is invalid: spec.selector: ... field is immutable
```
Root cause: `agentgateway-helm.yaml` installs the controller via Helm with
`releaseName: agentgateway`, which names the controller's own Deployment `agentgateway`.
The `Gateway` object this chart creates defaulted to the same name
(`gateway.name: agentgateway`), and the controller dynamically provisions a per-Gateway
dataplane Deployment named after the Gateway it manages — a direct collision with the
controller's own Deployment.

Renames the default `gateway.name` to `agentgateway-gw`. No template changes needed —
every template already parameterizes on `.Values.gateway.name`.

## Test plan
- [x] helm template shows Gateway/GatewayClass-parameters/UI-selector objects using the new name
- [x] helm lint passes