### PR TITLE
feat(agentgateway-bootstrap): wire up Bedrock IRSA auth via pod-identity webhook

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 
@@ -13,8 +13,9 @@ A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kuber
 | agentgatewayCrdsChart.repoURL | string | `"oci://cr.agentgateway.dev/charts"` |  |
 | agentgatewayCrdsChart.version | string | `"1.3.1"` |  |
 | argoProject | string | `"default"` |  |
+| bedrock.auth.roleArn | string | `""` |  |
 | bedrock.auth.secretName | string | `"bedrock-secret"` |  |
-| bedrock.auth.type | string | `"secret"` |  |
+| bedrock.auth.type | string | `"irsa"` |  |
 | bedrock.enabled | bool | `true` |  |
 | bedrock.model | string | `"amazon.nova-micro-v1:0"` |  |
 | bedrock.region | string | `"us-east-1"` |  |

--- a/charts/agentgateway-bootstrap/templates/gateway-parameters.yaml
+++ b/charts/agentgateway-bootstrap/templates/gateway-parameters.yaml
@@ -13,4 +13,10 @@ spec:
   service:
     spec:
       type: {{ .Values.gateway.service.type | default "ClusterIP" }}
+  {{- if and .Values.bedrock.enabled (eq .Values.bedrock.auth.type "irsa") .Values.bedrock.auth.roleArn }}
+  serviceAccount:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: {{ .Values.bedrock.auth.roleArn | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -31,8 +31,20 @@ bedrock:
   model: amazon.nova-micro-v1:0
   # Authentication configuration
   auth:
-    # Auth type: "secret", "irsa", or "implicit"
-    type: secret
+    # Auth type: "irsa" (default - IAM Roles for Service Accounts via the
+    # cluster's pod-identity webhook and an externally-provisioned IAM role;
+    # see roleArn below) or "secret" (static AWS credentials from a Kubernetes
+    # Secret).
+    type: irsa
+    # IAM role ARN to annotate the dataplane ServiceAccount with when
+    # auth.type is "irsa" (eks.amazonaws.com/role-arn). The cluster's
+    # pod-identity webhook then injects AWS_ROLE_ARN/AWS_WEB_IDENTITY_TOKEN_FILE
+    # into the dataplane pod, which performs sts:AssumeRoleWithWebIdentity
+    # against this role automatically - no further chart-side wiring needed.
+    # This role must already exist (trust policy + Bedrock permissions
+    # provisioned externally) - this chart does not create it. Required
+    # when auth.type is "irsa".
+    roleArn: ""
     # Secret name containing AWS credentials if auth.type is "secret"
     secretName: bedrock-secret
   # Route configuration for Bedrock


### PR DESCRIPTION
## Summary
Defaults `bedrock.auth.type` to `irsa` and adds `bedrock.auth.roleArn`. When set,
annotates the dynamically-provisioned dataplane's ServiceAccount with
`eks.amazonaws.com/role-arn` - the cluster's `amazon-eks-pod-identity-webhook` then
injects the AWS STS web-identity env vars into the pod automatically, and agentgateway's
Rust dataplane (which signs Bedrock requests) picks these up via the standard AWS SDK
credential chain with zero further wiring. No `AssumeRole` config needed in
`AgentgatewayBackend` - ambient/implicit auth is exactly the webhook-injected
credentials.

Same pattern already used by `hermes-agent`/`picoclaw` on this cluster. The IAM role
(trust policy + permissions) is provisioned externally; this chart only consumes the
ARN.

## Test plan
- [x] helm template with no roleArn set renders identically to before (no ServiceAccount block)
- [x] helm template with roleArn set renders the annotation correctly, alongside the existing service block
- [x] helm template confirms auth.type: secret does NOT render the annotation even if roleArn happens to be set
- [x] helm lint passes