### PR TITLE
feat(agentgateway-bootstrap): provision CNPG Postgres for cost tracking

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 
@@ -27,6 +27,15 @@ A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kuber
 | controller.resources.limits.memory | string | `"256Mi"` |  |
 | controller.resources.requests.cpu | string | `"100m"` |  |
 | controller.resources.requests.memory | string | `"128Mi"` |  |
+| database.clusterName | string | `""` |  |
+| database.databaseName | string | `"agentgateway"` |  |
+| database.enabled | bool | `true` |  |
+| database.instances | int | `1` |  |
+| database.resources.limits.memory | string | `"512Mi"` |  |
+| database.resources.requests.cpu | string | `"50m"` |  |
+| database.resources.requests.memory | string | `"128Mi"` |  |
+| database.storage.size | string | `"5Gi"` |  |
+| database.storage.storageClass | string | `""` |  |
 | environmentConfig.accountId | string | `""` |  |
 | environmentConfig.region | string | `""` |  |
 | environmentConfig.resourcePrefix | string | `""` |  |

--- a/charts/agentgateway-bootstrap/templates/postgres-cluster.yaml
+++ b/charts/agentgateway-bootstrap/templates/postgres-cluster.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.database.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.database.clusterName | default (printf "%s-db" .Values.gateway.name) }}
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  instances: {{ .Values.database.instances }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.database.databaseName | quote }}
+      owner: {{ .Values.database.databaseName | quote }}
+  storage:
+    size: {{ .Values.database.storage.size | quote }}
+    {{- if .Values.database.storage.storageClass }}
+    storageClass: {{ .Values.database.storage.storageClass | quote }}
+    {{- end }}
+  resources:
+    requests:
+      cpu: {{ .Values.database.resources.requests.cpu | quote }}
+      memory: {{ .Values.database.resources.requests.memory | quote }}
+    limits:
+      memory: {{ .Values.database.resources.limits.memory | quote }}
+{{- end }}

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -53,6 +53,32 @@ bedrock:
     path: /bedrock
     openAiPath: /v1/chat/completions
 
+# Postgres database for LLM cost tracking (agentgateway's request-logging DB, which
+# powers its cost dashboard and Analytics UI). Provisions a plain CNPG Cluster
+# directly - no Crossplane, no external-secrets dependency. CNPG generates its own
+# <clusterName>-app Secret (with a combined `uri` key) since bootstrap.initdb.secret
+# is left unset; a Job (separate from this values block) reads that key and wires it
+# into AgentgatewayParameters.spec.rawConfig.database.url.
+database:
+  # Provision a CNPG Cluster for agentgateway's request-logging database.
+  enabled: true
+  # Cluster resource name. Defaults to "<gateway.name>-db" if unset.
+  clusterName: ""
+  # Number of CNPG instances (1 = no HA, single replica).
+  instances: 1
+  # Database (and owner role) name.
+  databaseName: agentgateway
+  storage:
+    size: 5Gi
+    # Leave empty to use the cluster's default StorageClass.
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
 # Kubernetes Gateway resource configuration
 gateway:
   enabled: true


### PR DESCRIPTION
## Summary
Adds a plain CNPG `Cluster` resource (no Crossplane, no external-secrets, no `helm
lookup`) for agentgateway's request-logging database, which powers its cost dashboard
and Analytics UI. `bootstrap.initdb.secret` is deliberately left unset so CNPG
generates its own `<name>-app` Secret, which already includes a combined `uri` key
usable directly as agentgateway's `database.url`.

Wiring that `uri` value into `AgentgatewayParameters.spec.rawConfig.database.url` (a
static-only field with no secret-ref mechanism) requires a step that runs after the
Secret exists — a follow-up PR adds a Job for that. This PR is just the `Cluster`
resource and its values.

## Test plan
- [x] helm template renders a Cluster with no bootstrap.initdb.secret field
- [x] database.enabled=false renders no Cluster at all
- [x] helm lint passes