### PR TITLE
feat(agentgateway-bootstrap): wire CNPG connection URI into AgentgatewayParameters

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.7
+version: 0.4.8
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 

--- a/charts/agentgateway-bootstrap/templates/_helpers.tpl
+++ b/charts/agentgateway-bootstrap/templates/_helpers.tpl
@@ -75,6 +75,13 @@ Usage: include "agentgateway-bootstrap.substituteVars" (dict "str" .Values.myVal
 {{/*
 Validate required configuration values
 */}}
+{{/*
+Name of the CNPG Cluster provisioned for LLM cost tracking.
+*/}}
+{{- define "agentgateway-bootstrap.postgresClusterName" -}}
+{{- .Values.database.clusterName | default (printf "%s-db" .Values.gateway.name) -}}
+{{- end }}
+
 {{- define "agentgateway-bootstrap.validateConfig" -}}
 {{- if not .Values.argoProject }}
 {{- fail "argoProject is required and cannot be empty" }}

--- a/charts/agentgateway-bootstrap/templates/postgres-cluster.yaml
+++ b/charts/agentgateway-bootstrap/templates/postgres-cluster.yaml
@@ -2,7 +2,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: {{ .Values.database.clusterName | default (printf "%s-db" .Values.gateway.name) }}
+  name: {{ include "agentgateway-bootstrap.postgresClusterName" . }}
   namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
   labels:
     {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}

--- a/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
+++ b/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.database.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentgateway-bootstrap.fullname" . }}-postgres-wire
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "2"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agentgateway-bootstrap.fullname" . }}-postgres-wire
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "2"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "watch"]
+  - apiGroups: ["agentgateway.dev"]
+    resources: ["agentgatewayparameters"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agentgateway-bootstrap.fullname" . }}-postgres-wire
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "2"
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agentgateway-bootstrap.fullname" . }}-postgres-wire
+    namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+roleRef:
+  kind: Role
+  name: {{ include "agentgateway-bootstrap.fullname" . }}-postgres-wire
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agentgateway-bootstrap.fullname" . }}-postgres-wire
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  backoffLimit: 4
+  template:
+    metadata: {}
+    spec:
+      serviceAccountName: {{ include "agentgateway-bootstrap.fullname" . }}-postgres-wire
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wire-database-url
+          # renovate: datasource=docker depName=alpine/k8s
+          image: alpine/k8s:1.36.2
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          env:
+            - name: NAMESPACE
+              value: {{ .Values.gateway.namespace | default "agentgateway-system" | quote }}
+            - name: CLUSTER_NAME
+              value: {{ include "agentgateway-bootstrap.postgresClusterName" . | quote }}
+            - name: PARAMS_NAME
+              value: {{ printf "%s-params" .Values.gateway.name | quote }}
+            - name: APP_SECRET_NAME
+              value: {{ printf "%s-app" (include "agentgateway-bootstrap.postgresClusterName" .) | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Waiting for CNPG cluster $CLUSTER_NAME to be ready..."
+              kubectl wait --for=condition=Ready cluster.postgresql.cnpg.io/"$CLUSTER_NAME" \
+                -n "$NAMESPACE" --timeout=300s
+
+              echo "Reading connection URI from $APP_SECRET_NAME..."
+              DATABASE_URL=$(kubectl get secret "$APP_SECRET_NAME" -n "$NAMESPACE" \
+                -o jsonpath='{.data.uri}' | base64 -d)
+
+              echo "Patching AgentgatewayParameters/$PARAMS_NAME with database.url..."
+              PATCH=$(printf '{"spec":{"rawConfig":{"database":{"url":"%s"}}}}' "$DATABASE_URL")
+              kubectl patch agentgatewayparameters "$PARAMS_NAME" -n "$NAMESPACE" \
+                --type merge -p "$PATCH"
+
+              echo "Done."
+{{- end }}

--- a/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
+++ b/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
@@ -31,7 +31,7 @@ rules:
     verbs: ["get", "watch"]
   - apiGroups: ["agentgateway.dev"]
     resources: ["agentgatewayparameters"]
-    verbs: ["get", "patch"]
+    verbs: ["patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -107,7 +107,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              set -e
+              set -eo pipefail
               echo "Waiting for CNPG cluster $CLUSTER_NAME to be ready..."
               kubectl wait --for=condition=Ready cluster.postgresql.cnpg.io/"$CLUSTER_NAME" \
                 -n "$NAMESPACE" --timeout=300s
@@ -115,9 +115,13 @@ spec:
               echo "Reading connection URI from $APP_SECRET_NAME..."
               DATABASE_URL=$(kubectl get secret "$APP_SECRET_NAME" -n "$NAMESPACE" \
                 -o jsonpath='{.data.uri}' | base64 -d)
+              if [ -z "$DATABASE_URL" ]; then
+                echo "ERROR: decoded database URL is empty" >&2
+                exit 1
+              fi
 
               echo "Patching AgentgatewayParameters/$PARAMS_NAME with database.url..."
-              PATCH=$(printf '{"spec":{"rawConfig":{"database":{"url":"%s"}}}}' "$DATABASE_URL")
+              PATCH=$(jq -n --arg url "$DATABASE_URL" '{spec:{rawConfig:{database:{url:$url}}}}')
               kubectl patch agentgatewayparameters "$PARAMS_NAME" -n "$NAMESPACE" \
                 --type merge -p "$PATCH"
 


### PR DESCRIPTION
## Summary
Follow-up to #305 (CNPG `Cluster` provisioning). `agentgateway`'s `database.url` (the
request-logging DB config powering its cost dashboard/Analytics UI) is a static
config-file field — confirmed via agentgateway's own Rust source and JSON schema, it
has no env-var override and no secret-ref mechanism of any kind.

CNPG generates its own `<cluster>-app` Secret once the `Cluster` is `Ready`, already
including a combined `uri` key in `postgresql://user:pass@host:port/dbname` format
(confirmed via CNPG's own source, `pkg/specs/secrets.go`). This adds an ArgoCD
`Sync`-hook `Job` — `ServiceAccount` + `Role` + `RoleBinding` + `Job`, matching the
existing pattern in `charts/grafana/templates/grafana-credentials-job.yaml` — that
waits for the `Cluster` to report `Ready`, reads that `uri` key, and
`kubectl patch`es it into `AgentgatewayParameters.spec.rawConfig.database.url`.

No `helm lookup`, no External Secrets Operator, no Crossplane — idempotency comes from
the Job's own `kubectl wait`/`get` calls against live cluster state at Job-run time,
not from anything Helm renders statically.

Also extracts the CNPG `Cluster` name into a new
`agentgateway-bootstrap.postgresClusterName` helper so `postgres-cluster.yaml` and the
new `postgres-config-job.yaml` can't compute it differently and drift apart.

## Test plan
- [x] helm template shows the Job/ServiceAccount/Role/RoleBinding rendering correctly, with `CLUSTER_NAME`/`PARAMS_NAME`/`APP_SECRET_NAME` all resolving to the expected names
- [x] database.enabled=false renders none of these resources
- [x] helm lint passes