### PR TITLE
fix(agentgateway-bootstrap): restore get RBAC verb on agentgatewayparameters

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.8
+version: 0.4.9
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.9](https://img.shields.io/badge/Version-0.4.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 

--- a/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
+++ b/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
@@ -31,7 +31,10 @@ rules:
     verbs: ["get", "watch"]
   - apiGroups: ["agentgateway.dev"]
     resources: ["agentgatewayparameters"]
-    verbs: ["patch"]
+    # get is required too: `kubectl patch` fetches the current object before
+    # sending the merge patch. Confirmed live: patch-only RBAC is rejected
+    # with "cannot get resource agentgatewayparameters" on a real cluster.
+    verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary
A prior review round flagged `get` on `agentgatewayparameters` as unused RBAC scope
(the script only ever `patch`es the CR) and it was dropped in #306. Deploying to a
real cluster revealed this was incorrect: `kubectl patch` fetches the current object
before sending the merge patch, so `patch`-only RBAC is rejected:

```
Error from server (Forbidden): agentgatewayparameters.agentgateway.dev
"agentgateway-gw-params" is forbidden: User "system:serviceaccount:
agentgateway:agentgateway-bootstrap-postgres-wire" cannot get resource
"agentgatewayparameters" in API group "agentgateway.dev" in the
namespace "agentgateway"
```

Restores `get` alongside `patch`.

## Test plan
- [x] helm template shows `verbs: ["get", "patch"]` on the `agentgatewayparameters` rule
- [x] helm lint passes
- [x] Confirmed live on dip-ce-k3s-eu: the Job's `kubectl patch` succeeds with this RBAC