### PR TITLE
fix(agentgateway-bootstrap): nest database.url under rawConfig.config

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.9
+version: 0.4.10
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.9](https://img.shields.io/badge/Version-0.4.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 

--- a/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
+++ b/charts/agentgateway-bootstrap/templates/postgres-config-job.yaml
@@ -123,8 +123,15 @@ spec:
                 exit 1
               fi
 
-              echo "Patching AgentgatewayParameters/$PARAMS_NAME with database.url..."
-              PATCH=$(jq -n --arg url "$DATABASE_URL" '{spec:{rawConfig:{database:{url:$url}}}}')
+              echo "Patching AgentgatewayParameters/$PARAMS_NAME with config.database.url..."
+              # rawConfig merges at the top level of agentgateway's config file
+              # (config.yaml), whose schema is { config: {...}, binds: [...],
+              # policies: [...], ... } - the database URL lives under the
+              # nested `config:` key, not at rawConfig's own top level.
+              # `database: null` clears any stale top-level key from chart
+              # versions <=0.4.9, which patched the wrong path and left
+              # agentgateway unable to parse its config at all.
+              PATCH=$(jq -n --arg url "$DATABASE_URL" '{spec:{rawConfig:{config:{database:{url:$url}},database:null}}}')
               kubectl patch agentgatewayparameters "$PARAMS_NAME" -n "$NAMESPACE" \
                 --type merge -p "$PATCH"
 


### PR DESCRIPTION
## Summary
`AgentgatewayParameters.spec.rawConfig` merges at the top level of agentgateway's
config file (the `LocalConfig` type — fields `config`/`binds`/`frontendPolicies`/
`policies`/`workloads`/`services`/`backends`/`routeGroups`/`llm`/`mcp`), not at the
database-only `RawConfig` type directly. Chart versions ≤0.4.9 patched
`rawConfig.database.url`, which crashed every dataplane pod on config reload:

```
Error: database: unknown field `database`, expected one of `config`, `binds`,
`frontendPolicies`, `policies`, `workloads`, `services`, `backends`, `routeGroups`,
`llm`, `mcp` at line 1 column 11
```

Confirmed live on `dip-ce-k3s-eu`: moving the patch to `rawConfig.config.database.url`
fixes the crash immediately, and a follow-up end-to-end test (a real request through
`/v1/chat/completions`) was correctly recorded in the `request_logs` table.

The patch also clears any stale top-level `database` key a chart version ≤0.4.9 may
have already written, since a merge patch alone won't remove a sibling key.

## Test plan
- [x] helm template shows the corrected `rawConfig.config.database.url` nesting in the patch payload
- [x] helm lint passes
- [x] Confirmed live on dip-ce-k3s-eu: dataplane pod recovers from CrashLoopBackOff, ConfigMap regenerates with `config: database: url:`, and a real LLM request is recorded in `request_logs`