### PR TITLE
feat(agentgateway-bootstrap): add optional JWT authentication

### DIFF
--- a/charts/agentgateway-bootstrap/Chart.yaml
+++ b/charts/agentgateway-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agentgateway-bootstrap
 description: A Helm chart for bootstrapping agentgateway with Amazon Bedrock LLM support
 type: application
-version: 0.4.10
+version: 0.4.11
 appVersion: "1.3.1"
 keywords:
   - agentgateway

--- a/charts/agentgateway-bootstrap/README.md
+++ b/charts/agentgateway-bootstrap/README.md
@@ -1,6 +1,6 @@
 # agentgateway-bootstrap
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kubernetes via ArgoCD Applications.
 
@@ -44,6 +44,14 @@ A Helm chart for bootstrapping agentgateway with Amazon Bedrock support on Kuber
 | gateway.name | string | `"agentgateway-gw"` |  |
 | gateway.namespace | string | `"agentgateway-system"` |  |
 | gateway.service.type | string | `"ClusterIP"` |  |
+| jwt.audiences | list | `[]` |  |
+| jwt.cacheDuration | string | `"5m"` |  |
+| jwt.enabled | bool | `false` |  |
+| jwt.externalIssuer.host | string | `""` |  |
+| jwt.externalIssuer.jwksPath | string | `"/keys"` |  |
+| jwt.externalIssuer.port | int | `443` |  |
+| jwt.externalIssuer.sni | string | `""` |  |
+| jwt.issuer | string | `""` |  |
 | monitoring.enabled | bool | `true` |  |
 | monitoring.grafanaDashboard.enabled | bool | `true` |  |
 | monitoring.serviceMonitor.enabled | bool | `true` |  |

--- a/charts/agentgateway-bootstrap/templates/_helpers.tpl
+++ b/charts/agentgateway-bootstrap/templates/_helpers.tpl
@@ -92,4 +92,15 @@ Name of the CNPG Cluster provisioned for LLM cost tracking.
 {{- if not .Values.agentgatewayChart.version }}
 {{- fail "agentgatewayChart.version is required and cannot be empty" }}
 {{- end }}
+{{- if .Values.jwt.enabled }}
+{{- if not .Values.jwt.issuer }}
+{{- fail "jwt.issuer is required when jwt.enabled is true" }}
+{{- end }}
+{{- if not .Values.jwt.externalIssuer.host }}
+{{- fail "jwt.externalIssuer.host is required when jwt.enabled is true" }}
+{{- end }}
+{{- if not .Values.jwt.audiences }}
+{{- fail "jwt.audiences is required when jwt.enabled is true - an unset audiences list accepts a validly-signed JWT from the issuer regardless of which service it was minted for, which matters when the issuer is shared across multiple services" }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/agentgateway-bootstrap/templates/jwt-auth-policy.yaml
+++ b/charts/agentgateway-bootstrap/templates/jwt-auth-policy.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.jwt.enabled .Values.gateway.enabled }}
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: {{ include "agentgateway-bootstrap.fullname" . }}-jwt-auth
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.gateway.name | default "agentgateway" }}
+  traffic:
+    jwtAuthentication:
+      mode: Strict
+      providers:
+        - issuer: {{ .Values.jwt.issuer | quote }}
+          {{- if .Values.jwt.audiences }}
+          audiences:
+            {{- toYaml .Values.jwt.audiences | nindent 12 }}
+          {{- end }}
+          jwks:
+            remote:
+              jwksPath: {{ .Values.jwt.externalIssuer.jwksPath | quote }}
+              cacheDuration: {{ .Values.jwt.cacheDuration | quote }}
+              backendRef:
+                group: agentgateway.dev
+                kind: AgentgatewayBackend
+                name: {{ include "agentgateway-bootstrap.fullname" . }}-jwt-issuer
+                port: {{ .Values.jwt.externalIssuer.port }}
+{{- end }}

--- a/charts/agentgateway-bootstrap/templates/jwt-auth-policy.yaml
+++ b/charts/agentgateway-bootstrap/templates/jwt-auth-policy.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.jwt.enabled .Values.gateway.enabled }}
+{{- include "agentgateway-bootstrap.validateConfig" . -}}
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:

--- a/charts/agentgateway-bootstrap/templates/jwt-issuer-backend.yaml
+++ b/charts/agentgateway-bootstrap/templates/jwt-issuer-backend.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.jwt.enabled .Values.gateway.enabled }}
+{{- include "agentgateway-bootstrap.validateConfig" . -}}
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:

--- a/charts/agentgateway-bootstrap/templates/jwt-issuer-backend.yaml
+++ b/charts/agentgateway-bootstrap/templates/jwt-issuer-backend.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.jwt.enabled .Values.gateway.enabled }}
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: {{ include "agentgateway-bootstrap.fullname" . }}-jwt-issuer
+  namespace: {{ .Values.gateway.namespace | default "agentgateway-system" }}
+  labels:
+    {{- include "agentgateway-bootstrap.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  static:
+    host: {{ .Values.jwt.externalIssuer.host | quote }}
+    port: {{ .Values.jwt.externalIssuer.port }}
+  policies:
+    tls:
+      sni: {{ .Values.jwt.externalIssuer.sni | default .Values.jwt.externalIssuer.host | quote }}
+{{- end }}

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -96,6 +96,28 @@ gateway:
   service:
     type: ClusterIP
 
+# JWT authentication for the Gateway. Disabled by default - opt in once
+# clients are ready to send tokens from the configured issuer. When enabled,
+# validation is Strict: every request must carry a valid JWT.
+jwt:
+  enabled: false
+  # IdP that issued the JWT (must match the token's `iss` claim exactly).
+  issuer: ""
+  # Allowed `aud` claim values. Leave empty to accept any audience.
+  audiences: []
+  # External issuer reached over TLS (e.g. an OIDC provider outside the
+  # cluster). host/port target the issuer's JWKS endpoint; jwksPath is the
+  # path component of its jwks_uri (see the issuer's
+  # /.well-known/openid-configuration document).
+  externalIssuer:
+    host: ""
+    port: 443
+    jwksPath: /keys
+    # SNI to present in the TLS handshake. Defaults to externalIssuer.host
+    # when unset.
+    sni: ""
+  cacheDuration: 5m
+
 # Admin UI internal service configuration
 ui:
   # Enable internal ClusterIP Service for the read-only Admin UI (port 15000)

--- a/charts/agentgateway-bootstrap/values.yaml
+++ b/charts/agentgateway-bootstrap/values.yaml
@@ -103,7 +103,10 @@ jwt:
   enabled: false
   # IdP that issued the JWT (must match the token's `iss` claim exactly).
   issuer: ""
-  # Allowed `aud` claim values. Leave empty to accept any audience.
+  # Allowed `aud` claim values. Required when jwt.enabled is true - an
+  # unset list accepts any validly-signed token from the issuer regardless
+  # of which service it was minted for, which matters whenever the issuer
+  # is shared across multiple services (as most OIDC providers are).
   audiences: []
   # External issuer reached over TLS (e.g. an OIDC provider outside the
   # cluster). host/port target the issuer's JWKS endpoint; jwksPath is the


### PR DESCRIPTION
## Summary
Adds `jwt.enabled` (default `false`) to gate a new Gateway-wide `AgentgatewayPolicy`
requiring a valid JWT (`mode: Strict`) on every request once enabled, per
https://agentgateway.dev/docs/kubernetes/latest/security/jwt/setup/.

Supports an external issuer reached over TLS
(https://agentgateway.dev/docs/kubernetes/latest/security/jwt/setup/#external-identity-provider-over-tls):
a new `AgentgatewayBackend` (`host`/`port` + TLS `sni`) that the policy's
`jwks.remote.backendRef` points at, since the JWKS source is outside the cluster, not
a `Service`.

New values:
- `jwt.issuer` / `jwt.audiences` — standard `iss`/`aud` claim validation
- `jwt.externalIssuer.{host,port,jwksPath,sni}` — the issuer's JWKS endpoint (`host`/
  `jwksPath` come from the issuer's own `/.well-known/openid-configuration` document,
  e.g. its `jwks_uri`)
- `jwt.cacheDuration` — local JWKS cache TTL (CRD-enforced minimum `5m`)

## Test plan
- [x] `jwt.enabled=false` (default) renders neither new resource
- [x] `jwt.enabled=true` with real values (issuer `https://issuer.rpi.loafoe.com`)
      renders both resources correctly — `AgentgatewayBackend` with the right
      host/port/SNI, `AgentgatewayPolicy` with `mode: Strict`, correct
      issuer/audiences/jwksPath, and a correctly cross-referenced `backendRef`
- [x] `helm lint` passes