### PR TITLE
updating iam groups, email paths

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: grafana
-version: 0.77.0
+version: 0.77.1

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -1,6 +1,6 @@
 # grafana
 
-![Version: 0.77.0](https://img.shields.io/badge/Version-0.77.0-informational?style=flat-square)
+![Version: 0.77.1](https://img.shields.io/badge/Version-0.77.1-informational?style=flat-square)
 
 Deploys Grafana to a cluster
 
@@ -72,6 +72,24 @@ this cluster by hand. Steps:
 If you're deploying to a cluster where Dex and Grafana genuinely run side-by-side (uncommon), the
 same `ProviderConfig`/`Client` pattern applies — just create both CRs locally instead of on a
 separate hub.
+
+### SSO Group to Role Mapping
+
+The following SSO configuration maps OIDC groups to Grafana roles:
+
+| Configuration | Value | Description |
+|---|---|---|
+| role_attribute_path | contains(join(' ', groups), 'grafana-superadmins') && 'GrafanaAdmin' \|\| contains(join(' ', groups), 'grafana-admins') && 'Admin' \|\| contains(join(' ', groups), 'grafana-editors') && 'Editor' \|\| contains(join(' ', groups), 'grafana-viewers') && 'Viewer' \|\| 'None' | JMESPath expression mapping OIDC groups to Grafana roles |
+| login_attribute_path | email | Extract login/username from OIDC claims |
+| email_attribute_path | email | Extract email from OIDC claims |
+
+**Required OIDC Groups:**
+- grafana-superadmins - Maps to GrafanaAdmin role
+- grafana-admins - Maps to Admin role
+- grafana-editors - Maps to Editor role
+- grafana-viewers - Maps to Viewer role
+
+Users not in any of these groups will have the 'None' role and no access.
 
 ## Values
 
@@ -149,7 +167,7 @@ separate hub.
 | grafana.ssoAuthEnabled | bool | `false` |  |
 | grafana.tenants | list | `[]` |  |
 | grafanaChart.releaseName | string | `"gf"` |  |
-| grafanaChart.version | string | `"12.8.0"` |  |
+| grafanaChart.version | string | `"12.8.1"` |  |
 | useCustomFqdn | bool | `true` |  |
 
 ----------------------------------------------

--- a/charts/grafana/README.md.gotmpl
+++ b/charts/grafana/README.md.gotmpl
@@ -73,6 +73,24 @@ If you're deploying to a cluster where Dex and Grafana genuinely run side-by-sid
 same `ProviderConfig`/`Client` pattern applies — just create both CRs locally instead of on a
 separate hub.
 
+### SSO Group to Role Mapping
+
+The following SSO configuration maps OIDC groups to Grafana roles:
+
+| Configuration | Value | Description |
+|---|---|---|
+| role_attribute_path | contains(join(' ', groups), 'grafana-superadmins') && 'GrafanaAdmin' \|\| contains(join(' ', groups), 'grafana-admins') && 'Admin' \|\| contains(join(' ', groups), 'grafana-editors') && 'Editor' \|\| contains(join(' ', groups), 'grafana-viewers') && 'Viewer' \|\| 'None' | JMESPath expression mapping OIDC groups to Grafana roles |
+| login_attribute_path | email | Extract login/username from OIDC claims |
+| email_attribute_path | email | Extract email from OIDC claims |
+
+**Required OIDC Groups:**
+- grafana-superadmins - Maps to GrafanaAdmin role
+- grafana-admins - Maps to Admin role
+- grafana-editors - Maps to Editor role
+- grafana-viewers - Maps to Viewer role
+
+Users not in any of these groups will have the 'None' role and no access.
+
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}

--- a/charts/grafana/config/grafana-values.yaml
+++ b/charts/grafana/config/grafana-values.yaml
@@ -249,9 +249,11 @@ grafana.ini:
     enabled: true
     name: OpenID Connect
     scopes: openid profile email groups offline_access
-    role_attribute_path: contains(join(' ', groups), 'grafana-superadmin') && 'GrafanaAdmin' || contains(join(' ', groups), 'grafana-admin')  && 'Admin' || contains(join(' ', groups), 'grafana-editor') && 'Editor' || contains(join(' ', groups), 'grafana-viewer') && 'Viewer' || 'None'
+    role_attribute_path: contains(join(' ', groups), 'grafana-superadmins') && 'GrafanaAdmin' || contains(join(' ', groups), 'grafana-admins')  && 'Admin' || contains(join(' ', groups), 'grafana-editors') && 'Editor' || contains(join(' ', groups), 'grafana-viewers') && 'Viewer' || 'None'
     role_attribute_strict: true
     org_attribute_path: groups
+    login_attribute_path: email
+    email_attribute_path: email
     client_id: ${clientId}
     client_secret: ${clientSecret}
     auth_url: ${issuerUrl}/auth{{- if .Values.grafana.connector }}/{{ .Values.grafana.connector }}{{- end }}


### PR DESCRIPTION
Updated the IAM group names , in IAM console the group names are "grafana-admins, grafana-editors, grafana-viewers" but in helm chart its without 's' **role_attribute_path: contains(join(' ', groups), 'grafana-superadmin') && 'GrafanaAdmin' || contains(join(' ', groups), 'grafana-admin') && 'Admin' || contains(join(' ', groups), 'grafana-editor') && 'Editor' || contains(join(' ', groups), 'grafana-viewer') && 'Viewer' || 'None'**
Also when the user logs through IAM , its loggin through code1 ID in grafana and not attaching any roles hence am trying with **login_attribute_path: email & email_attribute_path: email**