### PR TITLE
refactor: make SSO attribute paths configurable

### DIFF
--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: grafana
-version: 0.77.1
+version: 0.77.2

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -165,6 +165,9 @@ Users not in any of these groups will have the 'None' role and no access.
 | grafana.resources.requests.cpu | string | `"200m"` |  |
 | grafana.resources.requests.memory | string | `"256Mi"` |  |
 | grafana.ssoAuthEnabled | bool | `false` |  |
+| grafana.ssoEmailAttributePath | string | `"email"` |  |
+| grafana.ssoLoginAttributePath | string | `"email"` |  |
+| grafana.ssoRoleAttributePath | string | `"contains(join(' ', groups), 'grafana-superadmins') && 'GrafanaAdmin' || contains(join(' ', groups), 'grafana-admins')  && 'Admin' || contains(join(' ', groups), 'grafana-editors') && 'Editor' || contains(join(' ', groups), 'grafana-viewers') && 'Viewer' || 'None'"` |  |
 | grafana.tenants | list | `[]` |  |
 | grafanaChart.releaseName | string | `"gf"` |  |
 | grafanaChart.version | string | `"12.8.1"` |  |

--- a/charts/grafana/README.md
+++ b/charts/grafana/README.md
@@ -1,6 +1,6 @@
 # grafana
 
-![Version: 0.77.1](https://img.shields.io/badge/Version-0.77.1-informational?style=flat-square)
+![Version: 0.77.2](https://img.shields.io/badge/Version-0.77.2-informational?style=flat-square)
 
 Deploys Grafana to a cluster
 

--- a/charts/grafana/config/grafana-values.yaml
+++ b/charts/grafana/config/grafana-values.yaml
@@ -249,11 +249,11 @@ grafana.ini:
     enabled: true
     name: OpenID Connect
     scopes: openid profile email groups offline_access
-    role_attribute_path: contains(join(' ', groups), 'grafana-superadmins') && 'GrafanaAdmin' || contains(join(' ', groups), 'grafana-admins')  && 'Admin' || contains(join(' ', groups), 'grafana-editors') && 'Editor' || contains(join(' ', groups), 'grafana-viewers') && 'Viewer' || 'None'
+    role_attribute_path: {{ .Values.grafana.ssoRoleAttributePath | quote }}
     role_attribute_strict: true
     org_attribute_path: groups
-    login_attribute_path: email
-    email_attribute_path: email
+    login_attribute_path: {{ .Values.grafana.ssoLoginAttributePath | quote }}
+    email_attribute_path: {{ .Values.grafana.ssoEmailAttributePath | quote }}
     client_id: ${clientId}
     client_secret: ${clientSecret}
     auth_url: ${issuerUrl}/auth{{- if .Values.grafana.connector }}/{{ .Values.grafana.connector }}{{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -8,6 +8,13 @@ grafana:
   # Optional SSO connector path to auto-select upstream IDP (e.g., "github", "google")
   # When set, appends to auth_url: ${issuerUrl}/auth/${connector}
   connector: ""
+  # SSO OIDC group to Grafana role mapping (JMESPath expression)
+  # Maps groups from OIDC provider to Grafana roles
+  ssoRoleAttributePath: "contains(join(' ', groups), 'grafana-superadmins') && 'GrafanaAdmin' || contains(join(' ', groups), 'grafana-admins')  && 'Admin' || contains(join(' ', groups), 'grafana-editors') && 'Editor' || contains(join(' ', groups), 'grafana-viewers') && 'Viewer' || 'None'"
+  # SSO OIDC claim to use for login/username (JMESPath expression)
+  ssoLoginAttributePath: "email"
+  # SSO OIDC claim to use for email address (JMESPath expression)
+  ssoEmailAttributePath: "email"
   # Auth proxy configuration (for reverse proxy authentication)
   # See: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/auth-proxy/
   authProxy:


### PR DESCRIPTION
Adding template for grafana ini values as **Grafana-helm** application owns **gf-grafana** cm → renders **role_attribute_path** with old group names **grafana-kustomize** tries to patch that same cm → gets overwritten by grafana-helm immediately, hence updated the default values in values.yaml file to see if it picks up by cluster 